### PR TITLE
Replace delete and opIn_r so code compiles with DMD 2.100

### DIFF
--- a/jive/map.d
+++ b/jive/map.d
@@ -60,10 +60,10 @@ struct Map(Key, V)
 	}
 
 	/** returns: true if key is found in the map */
-	bool opIn_r(T)(auto ref const(T) key) const
+	bool opBinaryRight(string op : "in", T)(auto ref const(T) key) const
 		if(is(typeof(T.init == Key.init)))
 	{
-		return entries.opIn_r(key);
+		return key in entries;
 	}
 
 	/**

--- a/jive/orderedset.d
+++ b/jive/orderedset.d
@@ -8,6 +8,8 @@ module jive.orderedset;
 private import std.range;
 private import std.algorithm;
 private import std.functional;
+private import std.traits: hasElaborateDestructor;
+private import core.memory : GC;
 
 /**
  * An ordered set. Internally a red-black-tree. Value-semantics.
@@ -137,7 +139,7 @@ struct OrderedSet(V, alias _less = "a < b")
 	}
 
 	/** returns: true if value is found in the set */
-	bool opIn_r(T)(auto ref const(T) value) const
+	bool opBinaryRight(string op : "in", T)(auto ref const(T) value) const
 		if(is(typeof(less(T.init, V.init))))
 	{
 		return find(value) !is null;
@@ -242,7 +244,9 @@ struct OrderedSet(V, alias _less = "a < b")
 			n.parent.left = null;
 		else
 			n.parent.right = null;
-		delete n;
+		static if (hasElaborateDestructor!Node)
+			n.__xdtor();
+		GC.free(n);
 		return true;
 	}
 

--- a/jive/set.d
+++ b/jive/set.d
@@ -7,6 +7,8 @@ module jive.set;
 
 import std.algorithm;
 import std.range;
+import std.traits: hasElaborateDestructor;
+import core.memory : GC;
 
 /*
  *  TODO:
@@ -113,7 +115,7 @@ struct Set(V)
 				table[index] = m;
 			}
 
-		delete old;
+		GC.free(old.ptr);
 	}
 
 
@@ -149,7 +151,7 @@ struct Set(V)
 	}
 
 	/** returns: true if value is found in the set */
-	bool opIn_r(T)(auto ref const(T) value) const
+	bool opBinaryRight(string op : "in", T)(auto ref const(T) value) const
 		if(is(typeof(T.init == V.init)))
 	{
 		return findNode(value) !is null;
@@ -219,7 +221,9 @@ struct Set(V)
 				{
 					Node* x = *node;
 					*node = (*node).next;
-					delete x;
+					static if (hasElaborateDestructor!Node)
+						x.__xdtor();
+					GC.free(x);
 					--count;
 					return true;
 				}


### PR DESCRIPTION
`delete`: [deprecated since DMD 2.079](https://dlang.org/changelog/2.079.0.html#deprecate_delete), [error since DMD 2.100](https://dlang.org/changelog/2.100.0.html#deprecation_delete)
`opIn_r`: [deprecated since DMD 2.088](https://dlang.org/changelog/2.088.0.html#dep_d1_ops), [error since DMD 2.100](https://dlang.org/changelog/2.100.0.html#d1_style_operators)